### PR TITLE
Add support for pattern()

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -222,6 +222,16 @@ Ranges of numbers are specified using a combination of `min()` and `max()`:
 $schema = Expect::int()->min(10)->max(20);
 ```
 
+Regular expressions
+-------------------
+
+String can be restricted by regular expression using the `pattern()`:
+
+```php
+// just 9 numbers
+$schema = Expect::pattern('\d{9}');
+```
+
 Data mapping to objects
 -----------------------
 

--- a/src/Schema/Elements/Type.php
+++ b/src/Schema/Elements/Type.php
@@ -30,6 +30,9 @@ final class Type implements Schema
 	/** @var array */
 	private $range = [null, null];
 
+	/** @var string|null */
+	private $pattern;
+
 
 	public function __construct(string $type)
 	{
@@ -73,6 +76,13 @@ final class Type implements Schema
 	public function items($type = 'mixed'): self
 	{
 		$this->items = $type instanceof Schema ? $type : new self($type);
+		return $this;
+	}
+
+
+	public function pattern(string $pattern): self
+	{
+		$this->pattern = $pattern;
 		return $this;
 	}
 
@@ -126,6 +136,9 @@ final class Type implements Schema
 		}
 
 		$expected = $this->type . ($this->range === [null, null] ? '' : ':' . implode('..', $this->range));
+		if ($this->pattern !== null) {
+			$expected = $this->type . ':' . $this->pattern;
+		}
 		if (!$this->doValidate($value, $expected, $context)) {
 			return;
 		}

--- a/src/Schema/Expect.php
+++ b/src/Schema/Expect.php
@@ -43,6 +43,14 @@ final class Expect
 	}
 
 
+	public static function pattern(string $pattern): Type
+	{
+		$type = new Type('pattern');
+		$type->pattern($pattern);
+		return $type;
+	}
+
+
 	public static function type(string $type): Type
 	{
 		return new Type($type);

--- a/tests/Schema/Expect.pattern.phpt
+++ b/tests/Schema/Expect.pattern.phpt
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Nette\Schema\Expect;
+use Nette\Schema\Processor;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+test(function () {
+	$schema = Expect::pattern('\d{9}');
+
+	Assert::same('123456789', (new Processor)->process($schema, '123456789'));
+});
+
+
+test(function () {
+	$schema = Expect::pattern('\d{9}');
+
+	checkValidationErrors(function () use ($schema) {
+		(new Processor)->process($schema, '123');
+	}, ['The option expects to be pattern in range \d{9}, string \'123\' given.']);
+});


### PR DESCRIPTION
- new feature
- BC break? no

This PR adds support for `pattern()` method for validating schema with power of regular expressions.
