### PR TITLE
Allow Schema elements as default values

### DIFF
--- a/src/Schema/Elements/Base.php
+++ b/src/Schema/Elements/Base.php
@@ -11,7 +11,7 @@ namespace Nette\Schema\Elements;
 
 use Nette;
 use Nette\Schema\Context;
-
+use Nette\Schema\Schema;
 
 /**
  * @internal
@@ -74,6 +74,9 @@ trait Base
 		if ($this->required) {
 			$context->addError('The mandatory option %path% is missing.');
 			return null;
+		}
+		if ($this->default instanceof Schema) {
+			return $this->default->completeDefault($context);
 		}
 		return $this->default;
 	}

--- a/tests/Schema/Expect.anyOf.phpt
+++ b/tests/Schema/Expect.anyOf.phpt
@@ -161,3 +161,15 @@ test(function () { // processing
 	Assert::same('two', $processor->processMultiple($schema, ['one', 'two']));
 	Assert::same(null, $processor->processMultiple($schema, ['one', null]));
 });
+
+test(function () { // Schema as default value
+	$default = Expect::structure([
+		'key2' => Expect::string(),
+	])->castTo('array');
+
+	$schema = Expect::structure([
+		'key1' => Expect::anyOf(false, $default)->default($default),
+	])->castTo('array');
+
+	Assert::same(['key1' => ['key2' => null]], (new Processor)->process($schema, null));
+});


### PR DESCRIPTION
- new feature?
- BC break? no

We have some composite extensions which simulates compiler passes. They can be disabled so configuration looks like this `Expect::anyOf(false, SubExtension::createSchema())`.

AnyOf does not match default value null (empty configuration) same way as if we directly use Expect::structure (no AnyOf) so that structure is not used.

Current workaround looks like this

```php
	public function getConfigSchema(): Schema
	{
		$subExtensionSchema = SubExtension::createSchema();

		return Expect::structure([
			'subExtension' => Expect::anyOf(false, $subExtensionSchema)->default($subExtensionSchema->completeDefault(new Context())),
		]);
	}
```

With suggested change would be simplified call to `default` to `default($subExtensionSchema)` and it also allows any schemas used as default values.

Alternative solution would be match Structure with null value in [AnyOf](https://github.com/nette/schema/blob/master/src/Schema/Elements/AnyOf.php#L69-L93) but I am not sure if it's a correct behavior as it would depend on order of structure and null if both used and maybe break also some other combinations.