### PR TITLE
Simplify error codes

### DIFF
--- a/src/Schema/Elements/AnyOf.php
+++ b/src/Schema/Elements/AnyOf.php
@@ -98,7 +98,7 @@ final class AnyOf implements Schema
 			$expecteds = implode('|', array_unique($expecteds));
 			$context->addError(
 				'The option %path% expects to be %expected%, %value% given.',
-				__CLASS__ . ':unexpected',
+				Nette\Schema\ValidationException::UNEXPECTED_VALUE,
 				['value' => $value, 'expected' => $expecteds]
 			);
 		}
@@ -110,7 +110,7 @@ final class AnyOf implements Schema
 		if ($this->required) {
 			$context->addError(
 				'The mandatory option %path% is missing.',
-				__CLASS__ . ':missing'
+				Nette\Schema\ValidationException::OPTION_MISSING
 			);
 			return null;
 		}

--- a/src/Schema/Elements/Base.php
+++ b/src/Schema/Elements/Base.php
@@ -74,7 +74,7 @@ trait Base
 		if ($this->required) {
 			$context->addError(
 				'The mandatory option %path% is missing.',
-				__CLASS__ . ':missing'
+				Nette\Schema\ValidationException::OPTION_MISSING
 			);
 			return null;
 		}
@@ -99,7 +99,7 @@ trait Base
 		} catch (Nette\Utils\AssertionException $e) {
 			$context->addError(
 				$e->getMessage(),
-				__CLASS__ . ':unexpected',
+				Nette\Schema\ValidationException::UNEXPECTED_VALUE,
 				['value' => $value, 'expected' => $expected]
 			);
 			return false;
@@ -122,7 +122,7 @@ trait Base
 				$expected = $description ? ('"' . $description . '"') : (is_string($handler) ? "$handler()" : "#$i");
 				$context->addError(
 					'Failed assertion %assertion% for option %path% with value %value%.',
-					__CLASS__ . ':assertion',
+					Nette\Schema\ValidationException::FAILED_ASSERTION,
 					['value' => $value, 'assertion' => $expected]
 				);
 				return;

--- a/src/Schema/Elements/Structure.php
+++ b/src/Schema/Elements/Structure.php
@@ -145,7 +145,7 @@ final class Structure implements Schema
 					$hint = Nette\Utils\Helpers::getSuggestion($keys, (string) $key);
 					$context->addError(
 						'Unexpected option %path%' . ($hint ? ", did you mean '%hint%'?" : '.'),
-						__CLASS__ . ':unexpected',
+						Nette\Schema\ValidationException::UNEXPECTED_STRUCTURE_KEY,
 						[
 							'path' => array_merge($context->path, [$key]),
 							'hint' => $hint,

--- a/src/Schema/Elements/Type.php
+++ b/src/Schema/Elements/Type.php
@@ -142,7 +142,7 @@ final class Type implements Schema
 		if ($this->pattern !== null && !preg_match("\x01^(?:$this->pattern)$\x01Du", $value)) {
 			$context->addError(
 				"The option %path% expects to match pattern '%pattern%', %value% given.",
-				__CLASS__ . ':unexpected',
+				Nette\Schema\ValidationException::PATTERN_MISMATCH,
 				['value' => $value, 'pattern' => $this->pattern]
 			);
 			return;

--- a/src/Schema/ValidationException.php
+++ b/src/Schema/ValidationException.php
@@ -17,6 +17,28 @@ use Nette;
  */
 class ValidationException extends Nette\InvalidStateException
 {
+
+    /**
+     * extra variables: []
+     */
+    public const OPTION_MISSING = 'schema.optionMissing';
+    /**
+     * extra variables: ['value' => string, 'pattern' => string]
+     */
+    public const PATTERN_MISMATCH = 'schema.patternMismatch';
+    /**
+     * extra variables: ['value' => string, 'expected' => string]
+     */
+    public const UNEXPECTED_VALUE = 'schema.unexpectedValue';
+    /**
+     * extra variables: ['value' => string, 'assertion' => string]
+     */
+    public const FAILED_ASSERTION = 'schema.failedAssertion';
+    /**
+     * extra variables: ['value' => string, 'hint' => string]
+     */
+    public const UNEXPECTED_STRUCTURE_KEY = 'schema.structure.unexpectedKey';
+
 	/** @var \stdClass[] */
 	private $errors;
 


### PR DESCRIPTION
- new feature
- BC break? no
- doc PR: nette/docs#???  none (yet)

# Proposal description
Use language-independent plain error codes to provide easier localization support. Discussion is at https://forum.nette.org/cs/33448