### PR TITLE
Type: Min and Max can be int, float or null.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "1.0-dev"
+			"dev-master": "1.1-dev"
 		}
 	}
 }

--- a/src/Schema/Context.php
+++ b/src/Schema/Context.php
@@ -32,8 +32,13 @@ final class Context
 	public $dynamics = [];
 
 
-	public function addError($message, $hint = null)
+	public function addError(string $message, string $code, string $hint = null)
 	{
-		$this->errors[] = (object) ['message' => $message, 'path' => $this->path, 'hint' => $hint];
+		$this->errors[] = (object) [
+			'message' => $message,
+			'path' => $this->path,
+			'code' => $code,
+			'hint' => $hint,
+		];
 	}
 }

--- a/src/Schema/Context.php
+++ b/src/Schema/Context.php
@@ -32,13 +32,12 @@ final class Context
 	public $dynamics = [];
 
 
-	public function addError(string $message, string $code, string $hint = null)
+	public function addError(string $message, string $code, array $extra = [])
 	{
-		$this->errors[] = (object) [
+		$this->errors[] = (object) ($extra + [
 			'message' => $message,
 			'path' => $this->path,
 			'code' => $code,
-			'hint' => $hint,
-		];
+		]);
 	}
 }

--- a/src/Schema/Elements/AnyOf.php
+++ b/src/Schema/Elements/AnyOf.php
@@ -96,7 +96,10 @@ final class AnyOf implements Schema
 			$context->errors = array_merge($context->errors, $innerErrors);
 		} else {
 			$hints = implode('|', array_unique($hints));
-			$context->addError("The option %path% expects to be $hints, " . static::formatValue($value) . ' given.');
+			$context->addError(
+				"The option %path% expects to be $hints, " . static::formatValue($value) . ' given.',
+				__CLASS__ . ':unexpected'
+			);
 		}
 	}
 
@@ -104,7 +107,10 @@ final class AnyOf implements Schema
 	public function completeDefault(Context $context)
 	{
 		if ($this->required) {
-			$context->addError('The mandatory option %path% is missing.');
+			$context->addError(
+				'The mandatory option %path% is missing.',
+				__CLASS__ . ':missing'
+			);
 			return null;
 		}
 		if ($this->default instanceof Schema) {

--- a/src/Schema/Elements/AnyOf.php
+++ b/src/Schema/Elements/AnyOf.php
@@ -88,7 +88,7 @@ final class AnyOf implements Schema
 				if ($item === $value) {
 					return $this->doFinalize($value, $context);
 				}
-				$expecteds[] = static::formatValue($item);
+				$expecteds[] = Nette\Schema\ValidationException::formatValue($item);
 			}
 		}
 
@@ -97,8 +97,9 @@ final class AnyOf implements Schema
 		} else {
 			$expecteds = implode('|', array_unique($expecteds));
 			$context->addError(
-				"The option %path% expects to be $expecteds, " . static::formatValue($value) . ' given.',
-				__CLASS__ . ':unexpected'
+				'The option %path% expects to be %expected%, %value% given.',
+				__CLASS__ . ':unexpected',
+				['value' => $value, 'expected' => $expecteds]
 			);
 		}
 	}

--- a/src/Schema/Elements/AnyOf.php
+++ b/src/Schema/Elements/AnyOf.php
@@ -68,7 +68,7 @@ final class AnyOf implements Schema
 
 	public function complete($value, Nette\Schema\Context $context)
 	{
-		$hints = $innerErrors = [];
+		$expecteds = $innerErrors = [];
 		foreach ($this->set as $item) {
 			if ($item instanceof Schema) {
 				$dolly = new Context;
@@ -78,26 +78,26 @@ final class AnyOf implements Schema
 					return $this->doFinalize($res, $context);
 				}
 				foreach ($dolly->errors as $error) {
-					if ($error->path !== $context->path || !$error->hint) {
+					if ($error->path !== $context->path || empty($error->expected)) {
 						$innerErrors[] = $error;
 					} else {
-						$hints[] = $error->hint;
+						$expecteds[] = $error->expected;
 					}
 				}
 			} else {
 				if ($item === $value) {
 					return $this->doFinalize($value, $context);
 				}
-				$hints[] = static::formatValue($item);
+				$expecteds[] = static::formatValue($item);
 			}
 		}
 
 		if ($innerErrors) {
 			$context->errors = array_merge($context->errors, $innerErrors);
 		} else {
-			$hints = implode('|', array_unique($hints));
+			$expecteds = implode('|', array_unique($expecteds));
 			$context->addError(
-				"The option %path% expects to be $hints, " . static::formatValue($value) . ' given.',
+				"The option %path% expects to be $expecteds, " . static::formatValue($value) . ' given.',
 				__CLASS__ . ':unexpected'
 			);
 		}

--- a/src/Schema/Elements/AnyOf.php
+++ b/src/Schema/Elements/AnyOf.php
@@ -98,7 +98,7 @@ final class AnyOf implements Schema
 			$expecteds = implode('|', array_unique($expecteds));
 			$context->addError(
 				'The option %path% expects to be %expected%, %value% given.',
-				__CLASS__ . ':unexpected',
+				Nette\Schema\ValidationException::UNEXPECTED_VALUE,
 				['value' => $value, 'expected' => $expecteds]
 			);
 		}
@@ -110,7 +110,7 @@ final class AnyOf implements Schema
 		if ($this->required) {
 			$context->addError(
 				'The mandatory option %path% is missing.',
-				__CLASS__ . ':missing'
+				Nette\Schema\ValidationException::OPTION_MISSING
 			);
 			return null;
 		}

--- a/src/Schema/Elements/Base.php
+++ b/src/Schema/Elements/Base.php
@@ -100,7 +100,7 @@ trait Base
 			$context->addError(
 				$e->getMessage(),
 				__CLASS__ . ':unexpected',
-				['expected' => $expected]
+				['value' => $value, 'expected' => $expected]
 			);
 			return false;
 		}
@@ -121,27 +121,14 @@ trait Base
 			if (!$handler($value)) {
 				$expected = $description ? ('"' . $description . '"') : (is_string($handler) ? "$handler()" : "#$i");
 				$context->addError(
-					"Failed assertion $expected for option %path% with value " . static::formatValue($value) . '.',
-					__CLASS__ . ':assertion'
+					'Failed assertion %assertion% for option %path% with value %value%.',
+					__CLASS__ . ':assertion',
+					['value' => $value, 'assertion' => $expected]
 				);
 				return;
 			}
 		}
 
 		return $value;
-	}
-
-
-	private static function formatValue($value): string
-	{
-		if (is_string($value)) {
-			return "'$value'";
-		} elseif (is_bool($value)) {
-			return $value ? 'true' : 'false';
-		} elseif (is_scalar($value)) {
-			return (string) $value;
-		} else {
-			return strtolower(gettype($value));
-		}
 	}
 }

--- a/src/Schema/Elements/Base.php
+++ b/src/Schema/Elements/Base.php
@@ -72,7 +72,10 @@ trait Base
 	public function completeDefault(Context $context)
 	{
 		if ($this->required) {
-			$context->addError('The mandatory option %path% is missing.');
+			$context->addError(
+				'The mandatory option %path% is missing.',
+				__CLASS__ . ':missing'
+			);
 			return null;
 		}
 		return $this->default;
@@ -94,7 +97,11 @@ trait Base
 			Nette\Utils\Validators::assert($value, $expected, 'option %path%');
 			return true;
 		} catch (Nette\Utils\AssertionException $e) {
-			$context->addError($e->getMessage(), $expected);
+			$context->addError(
+				$e->getMessage(),
+				__CLASS__ . ':unexpected',
+				$expected
+			);
 			return false;
 		}
 	}
@@ -113,7 +120,10 @@ trait Base
 		foreach ($this->asserts as $i => [$handler, $description]) {
 			if (!$handler($value)) {
 				$expected = $description ? ('"' . $description . '"') : (is_string($handler) ? "$handler()" : "#$i");
-				$context->addError("Failed assertion $expected for option %path% with value " . static::formatValue($value) . '.');
+				$context->addError(
+					"Failed assertion $expected for option %path% with value " . static::formatValue($value) . '.',
+					__CLASS__ . ':assertion'
+				);
 				return;
 			}
 		}

--- a/src/Schema/Elements/Base.php
+++ b/src/Schema/Elements/Base.php
@@ -100,7 +100,7 @@ trait Base
 			$context->addError(
 				$e->getMessage(),
 				__CLASS__ . ':unexpected',
-				$expected
+				['expected' => $expected]
 			);
 			return false;
 		}

--- a/src/Schema/Elements/Base.php
+++ b/src/Schema/Elements/Base.php
@@ -74,7 +74,7 @@ trait Base
 		if ($this->required) {
 			$context->addError(
 				'The mandatory option %path% is missing.',
-				__CLASS__ . ':missing'
+				Nette\Schema\ValidationException::OPTION_MISSING
 			);
 			return null;
 		}
@@ -99,7 +99,7 @@ trait Base
 		} catch (Nette\Utils\AssertionException $e) {
 			$context->addError(
 				$e->getMessage(),
-				__CLASS__ . ':unexpected',
+				Nette\Schema\ValidationException::UNEXPECTED_VALUE,
 				['value' => $value, 'expected' => $expected]
 			);
 			return false;
@@ -122,7 +122,7 @@ trait Base
 				$expected = $description ? ('"' . $description . '"') : (is_string($handler) ? "$handler()" : "#$i");
 				$context->addError(
 					'Failed assertion %assertion% for option %path% with value %value%.',
-					__CLASS__ . ':assertion',
+					Nette\Schema\ValidationException::FAILED_ASSERTION,
 					['value' => $value, 'assertion' => $expected]
 				);
 				return;

--- a/src/Schema/Elements/Structure.php
+++ b/src/Schema/Elements/Structure.php
@@ -140,15 +140,18 @@ final class Structure implements Schema
 			if ($this->otherItems) {
 				$items += array_fill_keys($extraKeys, $this->otherItems);
 			} else {
-				$hint = Nette\Utils\Helpers::getSuggestion(array_map('strval', array_keys($items)), (string) $extraKeys[0]);
-				$s = implode("', '", array_map(function ($key) use ($context) {
-					return implode(' › ', array_merge($context->path, [$key]));
-				}, $hint ? [$extraKeys[0]] : $extraKeys));
-				$context->addError(
-					"Unexpected option '$s'" . ($hint ? ", did you mean '%hint%'?" : '.'),
-					__CLASS__ . ':unexpected',
-					['hint' => $hint]
-				);
+				$keys = array_map('strval', array_keys($items));
+				foreach ($extraKeys as $key) {
+					$hint = Nette\Utils\Helpers::getSuggestion($keys, (string) $key);
+					$context->addError(
+						'Unexpected option %path%' . ($hint ? ", did you mean '%hint%'?" : '.'),
+						__CLASS__ . ':unexpected',
+						[
+							'path' => array_merge($context->path, [$key]),
+							'hint' => $hint,
+						]
+					);
+				}
 			}
 		}
 

--- a/src/Schema/Elements/Structure.php
+++ b/src/Schema/Elements/Structure.php
@@ -144,7 +144,10 @@ final class Structure implements Schema
 				$s = implode("', '", array_map(function ($key) use ($context) {
 					return implode(' › ', array_merge($context->path, [$key]));
 				}, $hint ? [$extraKeys[0]] : $extraKeys));
-				$context->addError("Unexpected option '$s'" . ($hint ? ", did you mean '$hint'?" : '.'));
+				$context->addError(
+					"Unexpected option '$s'" . ($hint ? ", did you mean '$hint'?" : '.'),
+					__CLASS__ . ':unexpected'
+				);
 			}
 		}
 

--- a/src/Schema/Elements/Structure.php
+++ b/src/Schema/Elements/Structure.php
@@ -145,7 +145,7 @@ final class Structure implements Schema
 					$hint = Nette\Utils\Helpers::getSuggestion($keys, (string) $key);
 					$context->addError(
 						'Unexpected option %path%' . ($hint ? ", did you mean '%hint%'?" : '.'),
-						__CLASS__ . ':unexpected',
+						Nette\Schema\ValidationException::UNEXPECTED_STRUCTURE_KEY,
 						[
 							'path' => array_merge($context->path, [$key]),
 							'hint' => $hint,

--- a/src/Schema/Elements/Structure.php
+++ b/src/Schema/Elements/Structure.php
@@ -145,8 +145,9 @@ final class Structure implements Schema
 					return implode(' › ', array_merge($context->path, [$key]));
 				}, $hint ? [$extraKeys[0]] : $extraKeys));
 				$context->addError(
-					"Unexpected option '$s'" . ($hint ? ", did you mean '$hint'?" : '.'),
-					__CLASS__ . ':unexpected'
+					"Unexpected option '$s'" . ($hint ? ", did you mean '%hint%'?" : '.'),
+					__CLASS__ . ':unexpected',
+					['hint' => $hint]
 				);
 			}
 		}

--- a/src/Schema/Elements/Type.php
+++ b/src/Schema/Elements/Type.php
@@ -142,7 +142,7 @@ final class Type implements Schema
 		if ($this->pattern !== null && !preg_match("\x01^(?:$this->pattern)$\x01Du", $value)) {
 			$context->addError(
 				"The option %path% expects to match pattern '%pattern%', %value% given.",
-				__CLASS__ . ':unexpected',
+				Nette\Schema\ValidationException::PATTERN_MISMATCH,
 				['value' => $value, 'pattern' => $this->pattern]
 			);
 			return;

--- a/src/Schema/Elements/Type.php
+++ b/src/Schema/Elements/Type.php
@@ -141,8 +141,9 @@ final class Type implements Schema
 		}
 		if ($this->pattern !== null && !preg_match("\x01^(?:$this->pattern)$\x01Du", $value)) {
 			$context->addError(
-				"The option %path% expects to match pattern '$this->pattern', '$value' given.",
-				__CLASS__ . ':unexpected'
+				"The option %path% expects to match pattern '%pattern%', %value% given.",
+				__CLASS__ . ':unexpected',
+				['value' => $value, 'pattern' => $this->pattern]
 			);
 			return;
 		}

--- a/src/Schema/Elements/Type.php
+++ b/src/Schema/Elements/Type.php
@@ -140,7 +140,10 @@ final class Type implements Schema
 			return;
 		}
 		if ($this->pattern !== null && !preg_match("\x01^(?:$this->pattern)$\x01Du", $value)) {
-			$context->addError("The option %path% expects to match pattern '$this->pattern', '$value' given.");
+			$context->addError(
+				"The option %path% expects to match pattern '$this->pattern', '$value' given.",
+				__CLASS__ . ':unexpected'
+			);
 			return;
 		}
 

--- a/src/Schema/Elements/Type.php
+++ b/src/Schema/Elements/Type.php
@@ -56,16 +56,32 @@ final class Type implements Schema
 	}
 
 
-	public function min(?float $min): self
+	/**
+	 * @param float|int|null $min
+	 * @return self
+	 */
+	public function min($min): self
 	{
-		$this->range[0] = $min;
+		if (is_numeric($min) === false && $min !== null) {
+			throw new \InvalidArgumentException('Min must be numeric, but "' . gettype($min) . '" given.');
+		}
+
+		$this->range[0] = $min === null ? null : (float) $min;
 		return $this;
 	}
 
 
-	public function max(?float $max): self
+	/**
+	 * @param float|int|null $max
+	 * @return self
+	 */
+	public function max($max): self
 	{
-		$this->range[1] = $max;
+		if (is_numeric($max) === false && $max !== null) {
+			throw new \InvalidArgumentException('Max must be numeric, but "' . gettype($max) . '" given.');
+		}
+
+		$this->range[1] = $max === null ? null : (float) $max;
 		return $this;
 	}
 

--- a/src/Schema/Processor.php
+++ b/src/Schema/Processor.php
@@ -72,13 +72,8 @@ final class Processor
 
 	private function throwsErrors(Context $context): void
 	{
-		$messages = [];
-		foreach ($context->errors as $error) {
-			$pathStr = " '" . implode(' › ', $error->path) . "'";
-			$messages[] = str_replace(' %path%', $error->path ? $pathStr : '', $error->message);
-		}
-		if ($messages) {
-			throw new ValidationException($messages[0], $messages);
+		if ($context->errors) {
+			throw new ValidationException(null, $context->errors);
 		}
 	}
 

--- a/src/Schema/ValidationException.php
+++ b/src/Schema/ValidationException.php
@@ -17,6 +17,28 @@ use Nette;
  */
 class ValidationException extends Nette\InvalidStateException
 {
+
+    /**
+     * extra variables: []
+     */
+    public const OPTION_MISSING = 'schema.optionMissing';
+    /**
+     * extra variables: ['value' => string, 'pattern' => string]
+     */
+    public const PATTERN_MISMATCH = 'schema.patternMismatch';
+    /**
+     * extra variables: ['value' => string, 'expected' => string]
+     */
+    public const UNEXPECTED_VALUE = 'schema.unexpectedValue';
+    /**
+     * extra variables: ['value' => string, 'assertion' => string]
+     */
+    public const FAILED_ASSERTION = 'schema.failedAssertion';
+    /**
+     * extra variables: ['value' => string, 'hint' => string]
+     */
+    public const UNEXPECTED_STRUCTURE_KEY = 'schema.structure.unexpectedKey';
+
 	/** @var \stdClass[] */
 	private $errors;
 

--- a/src/Schema/ValidationException.php
+++ b/src/Schema/ValidationException.php
@@ -17,19 +17,45 @@ use Nette;
  */
 class ValidationException extends Nette\InvalidStateException
 {
-	/** @var array */
-	private $messages;
+	/** @var \stdClass[] */
+	private $errors;
 
 
-	public function __construct(string $message, array $messages = [])
+	/**
+	 * @param  \stdClass[]  $errors
+	 */
+	public function __construct(?string $message, array $errors = [])
 	{
-		parent::__construct($message);
-		$this->messages = $messages ?: [$message];
+		parent::__construct($message ?: self::formatMessage($errors[0]));
+		$this->errors = $errors;
 	}
 
 
+	/**
+	 * @return string[]
+	 */
 	public function getMessages(): array
 	{
-		return $this->messages;
+		$messages = [];
+		foreach ($this->errors as $error) {
+			$messages[] = $this->formatMessage($error);
+		}
+		return $messages;
+	}
+
+
+	/**
+	 * @return \stdClass[]
+	 */
+	public function getErrors(): array
+	{
+		return $this->errors;
+	}
+
+
+	private function formatMessage(\stdClass $error): string
+	{
+		$pathStr = " '" . implode(' › ', $error->path) . "'";
+		return str_replace(' %path%', $error->path ? $pathStr : '', $error->message);
 	}
 }

--- a/tests/Schema/Expect.structure.phpt
+++ b/tests/Schema/Expect.structure.phpt
@@ -17,7 +17,7 @@ test(function () { // without items
 
 	checkValidationErrors(function () use ($schema) {
 		(new Processor)->process($schema, [1, 2, 3]);
-	}, ["Unexpected option '0', '1', '2'."]);
+	}, ["Unexpected option '0'.", "Unexpected option '1'.", "Unexpected option '2'."]);
 
 	checkValidationErrors(function () use ($schema) {
 		(new Processor)->process($schema, ['key' => 'val']);
@@ -141,7 +141,8 @@ test(function () { // with indexed item
 	checkValidationErrors(function () use ($processor, $schema) {
 		$processor->process($schema, [1, 2, 3]);
 	}, [
-		"Unexpected option '1', '2'.",
+		"Unexpected option '1'.",
+		"Unexpected option '2'.",
 		"The option '0' expects to be string, int 1 given.",
 	]);
 
@@ -227,7 +228,11 @@ test(function () { // item with default value
 
 	checkValidationErrors(function () use ($schema) {
 		(new Processor)->process($schema, [1, 2, 3]);
-	}, ["Unexpected option '0', did you mean 'b'?"]);
+	}, [
+		"Unexpected option '0', did you mean 'b'?",
+		"Unexpected option '1', did you mean 'b'?",
+		"Unexpected option '2', did you mean 'b'?",
+	]);
 
 	Assert::equal((object) ['b' => 123], (new Processor)->process($schema, []));
 
@@ -318,6 +323,8 @@ test(function () { // structure items
 		(new Processor)->process($schema, [1, 2, 3]);
 	}, [
 		"Unexpected option '0', did you mean 'a'?",
+		"Unexpected option '1', did you mean 'a'?",
+		"Unexpected option '2', did you mean 'a'?",
 		"The mandatory option 'b › y' is missing.",
 	]);
 
@@ -354,7 +361,8 @@ test(function () { // structure items
 	checkValidationErrors(function () use ($schema) {
 		(new Processor)->process($schema, ['b' => ['x1' => 'val', 'x2' => 'val']]);
 	}, [
-		"Unexpected option 'b › x1', 'b › x2'.",
+		"Unexpected option 'b › x1'.",
+		"Unexpected option 'b › x2'.",
 		"The mandatory option 'b › y' is missing.",
 	]);
 


### PR DESCRIPTION
- bug fix
- BC break? yes

I think value of `min()` and `max()` method should be `int`, `float` or `null`, because current implementation make bad logic in configuration:

![Snímek obrazovky 2020-07-01 v 16 23 54](https://user-images.githubusercontent.com/4738758/86255983-117cf580-bbb8-11ea-975b-4624b216ca78.png)

Thanks!