### PR TITLE
Prevent merging default array values by default

### DIFF
--- a/.github/funding.yml
+++ b/.github/funding.yml
@@ -1,0 +1,2 @@
+github: dg
+custom: "https://nette.org/donate"

--- a/.github/workflows/coding-style.yml
+++ b/.github/workflows/coding-style.yml
@@ -1,0 +1,31 @@
+name: Coding Style
+
+on: [push, pull_request]
+
+jobs:
+    nette_cc:
+        name: Nette Code Checker
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: shivammathur/setup-php@v1
+              with:
+                  php-version: 7.4
+                  coverage: none
+
+            - run: composer create-project nette/code-checker temp/code-checker ^3 --no-progress
+            - run: php temp/code-checker/code-checker --strict-types --ignore "tests/*/fixtures"
+
+
+    nette_cs:
+        name: Nette Coding Standard
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: shivammathur/setup-php@v1
+              with:
+                  php-version: 7.4
+                  coverage: none
+
+            - run: composer create-project nette/coding-standard temp/coding-standard ^2 --no-progress
+            - run: php temp/coding-standard/ecs check src tests --config temp/coding-standard/coding-standard-php71.yml

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,21 @@
+name: Static Analysis (only informative)
+
+on:
+    push:
+        branches:
+          - master
+
+jobs:
+    phpstan:
+        name: PHPStan
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: shivammathur/setup-php@v1
+              with:
+                  php-version: 7.4
+                  coverage: none
+
+            - run: composer install --no-progress --prefer-dist
+            - run: composer phpstan
+              continue-on-error: true # is only informative

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,58 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+    tests:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                php: ['7.1', '7.2', '7.3', '7.4', '8.0']
+
+            fail-fast: false
+
+        name: PHP ${{ matrix.php }} tests
+        steps:
+            - uses: actions/checkout@v2
+            - uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php }}
+                  coverage: none
+
+            - run: composer install --no-progress --prefer-dist
+            - run: vendor/bin/tester tests -s -C
+            - if: failure()
+              uses: actions/upload-artifact@v2
+              with:
+                  name: output
+                  path: tests/**/output
+
+
+    lowest_dependencies:
+        name: Lowest Dependencies
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: shivammathur/setup-php@v1
+              with:
+                  php-version: 7.1
+                  coverage: none
+
+            - run: composer update --no-progress --prefer-dist --prefer-lowest --prefer-stable
+            - run: vendor/bin/tester tests -s -C
+
+
+    code_coverage:
+        name: Code Coverage
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: shivammathur/setup-php@v2
+              with:
+                  php-version: 7.4
+                  coverage: none
+
+            - run: composer install --no-progress --prefer-dist
+            - run: wget https://github.com/satooshi/php-coveralls/releases/download/v1.0.1/coveralls.phar
+            - run: vendor/bin/tester -p phpdbg tests -s -C --coverage ./coverage.xml --coverage-src ./src
+            - run: php coveralls.phar --verbose --config tests/.coveralls.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
     - 7.2
     - 7.3
     - 7.4
+    - nightly
 
 before_install:
     # turn off XDebug
@@ -62,7 +63,7 @@ jobs:
         -   stage: Code Coverage
 
 
-sudo: false
+dist: xenial
 
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ jobs:
 
 
         -   name: Nette Code Checker
+            php: 7.4
             install:
                 - travis_retry composer create-project nette/code-checker temp/code-checker ^3 --no-progress
             script:
@@ -34,6 +35,7 @@ jobs:
 
 
         -   name: Nette Coding Standard
+            php: 7.4
             install:
                 - travis_retry composer create-project nette/coding-standard temp/coding-standard ^2 --no-progress
             script:
@@ -47,7 +49,7 @@ jobs:
 
 
         -   stage: Code Coverage
-            php: 7.3
+            php: 7.4
             script:
                 - vendor/bin/tester -p phpdbg tests -s --coverage ./coverage.xml --coverage-src ./src
             after_script:

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "1.0-dev"
+			"dev-master": "1.1-dev"
 		}
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ Installation:
 composer require nette/schema
 ```
 
-It requires PHP version 7.1 and supports PHP up to 7.4.
+It requires PHP version 7.1 and supports PHP up to 8.0.
 
 
 Support Project

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,9 @@ try {
 }
 ```
 
+Method `$e->getMessages()` returns array of all message strings and `$e->getMessageObjects()` return all messages as [Nette\Schema\Message](https://api.nette.org/3.0/Nette/Schema/Message.html) objects.
+
+
 Defining Schema
 ---------------
 

--- a/readme.md
+++ b/readme.md
@@ -257,6 +257,20 @@ $processor->process($schema, ['additional' => 1]); // OK
 $processor->process($schema, ['additional' => true]); // ERROR
 ```
 
+Deprecations
+------------
+
+You can deprecate property using the `deprecated([string $message])` method. Deprecation notices are returned by `$processor->getWarnings()`.
+
+```php
+$schema = Expect::structure([
+	'old' => Expect::int()->deprecated('The option %path% is deprecated'),
+]);
+
+$processor->process($schema, ['old' => 1]); // OK
+$processor->getWarnings(); // ["The option 'old' is deprecated"]
+```
+
 Ranges: min() max()
 -------------------
 

--- a/src/Schema/Context.php
+++ b/src/Schema/Context.php
@@ -25,15 +25,15 @@ final class Context
 	/** @var string[] */
 	public $path = [];
 
-	/** @var \stdClass[] */
+	/** @var Message[] */
 	public $errors = [];
 
 	/** @var array[] */
 	public $dynamics = [];
 
 
-	public function addError($message, $expected = null)
+	public function addError($message, $expected = null): Message
 	{
-		$this->errors[] = (object) ['message' => $message, 'path' => $this->path, 'expected' => $expected];
+		return $this->errors[] = new Message($message, $this->path, ['expected' => $expected]);
 	}
 }

--- a/src/Schema/Context.php
+++ b/src/Schema/Context.php
@@ -32,8 +32,8 @@ final class Context
 	public $dynamics = [];
 
 
-	public function addError(string $message, string $code, string $expected = null): Message
+	public function addError(string $message, string $code, array $variables = []): Message
 	{
-		return $this->errors[] = new Message($message, $code, $this->path, ['expected' => $expected]);
+		return $this->errors[] = new Message($message, $code, $this->path, $variables);
 	}
 }

--- a/src/Schema/Context.php
+++ b/src/Schema/Context.php
@@ -32,8 +32,8 @@ final class Context
 	public $dynamics = [];
 
 
-	public function addError($message, $expected = null): Message
+	public function addError(string $message, string $code, string $expected = null): Message
 	{
-		return $this->errors[] = new Message($message, $this->path, ['expected' => $expected]);
+		return $this->errors[] = new Message($message, $code, $this->path, ['expected' => $expected]);
 	}
 }

--- a/src/Schema/Context.php
+++ b/src/Schema/Context.php
@@ -28,6 +28,9 @@ final class Context
 	/** @var Message[] */
 	public $errors = [];
 
+	/** @var Message[] */
+	public $warnings = [];
+
 	/** @var array[] */
 	public $dynamics = [];
 
@@ -35,5 +38,11 @@ final class Context
 	public function addError(string $message, string $code, array $variables = []): Message
 	{
 		return $this->errors[] = new Message($message, $code, $this->path, $variables);
+	}
+
+
+	public function addWarning(string $message, string $code, array $variables = []): Message
+	{
+		return $this->warnings[] = new Message($message, $code, $this->path, $variables);
 	}
 }

--- a/src/Schema/Context.php
+++ b/src/Schema/Context.php
@@ -32,8 +32,8 @@ final class Context
 	public $dynamics = [];
 
 
-	public function addError($message, $hint = null)
+	public function addError($message, $expected = null)
 	{
-		$this->errors[] = (object) ['message' => $message, 'path' => $this->path, 'hint' => $hint];
+		$this->errors[] = (object) ['message' => $message, 'path' => $this->path, 'expected' => $expected];
 	}
 }

--- a/src/Schema/Elements/AnyOf.php
+++ b/src/Schema/Elements/AnyOf.php
@@ -78,10 +78,10 @@ final class AnyOf implements Schema
 					return $this->doFinalize($res, $context);
 				}
 				foreach ($dolly->errors as $error) {
-					if ($error->path !== $context->path || !$error->expected) {
+					if ($error->path !== $context->path || !$error->variables['expected']) {
 						$innerErrors[] = $error;
 					} else {
-						$expecteds[] = $error->expected;
+						$expecteds[] = $error->variables['expected'];
 					}
 				}
 			} else {

--- a/src/Schema/Elements/AnyOf.php
+++ b/src/Schema/Elements/AnyOf.php
@@ -78,7 +78,7 @@ final class AnyOf implements Schema
 					return $this->doFinalize($res, $context);
 				}
 				foreach ($dolly->errors as $error) {
-					if ($error->path !== $context->path || !$error->variables['expected']) {
+					if ($error->path !== $context->path || empty($error->variables['expected'])) {
 						$innerErrors[] = $error;
 					} else {
 						$expecteds[] = $error->variables['expected'];
@@ -88,17 +88,20 @@ final class AnyOf implements Schema
 				if ($item === $value) {
 					return $this->doFinalize($value, $context);
 				}
-				$expecteds[] = static::formatValue($item);
+				$expecteds[] = Nette\Schema\Message::formatValue($item);
 			}
 		}
 
 		if ($innerErrors) {
 			$context->errors = array_merge($context->errors, $innerErrors);
 		} else {
-			$expecteds = implode('|', array_unique($expecteds));
 			$context->addError(
-				"The option %path% expects to be $expecteds, " . static::formatValue($value) . ' given.',
-				Nette\Schema\Message::UNEXPECTED_VALUE
+				'The option %path% expects to be %expected%, %value% given.',
+				Nette\Schema\Message::UNEXPECTED_VALUE,
+				[
+					'value' => $value,
+					'expected' => implode('|', array_unique($expecteds)),
+				]
 			);
 		}
 	}

--- a/src/Schema/Elements/AnyOf.php
+++ b/src/Schema/Elements/AnyOf.php
@@ -96,7 +96,10 @@ final class AnyOf implements Schema
 			$context->errors = array_merge($context->errors, $innerErrors);
 		} else {
 			$expecteds = implode('|', array_unique($expecteds));
-			$context->addError("The option %path% expects to be $expecteds, " . static::formatValue($value) . ' given.');
+			$context->addError(
+				"The option %path% expects to be $expecteds, " . static::formatValue($value) . ' given.',
+				Nette\Schema\Message::UNEXPECTED_VALUE
+			);
 		}
 	}
 
@@ -104,7 +107,10 @@ final class AnyOf implements Schema
 	public function completeDefault(Context $context)
 	{
 		if ($this->required) {
-			$context->addError('The mandatory option %path% is missing.');
+			$context->addError(
+				'The mandatory option %path% is missing.',
+				Nette\Schema\Message::OPTION_MISSING
+			);
 			return null;
 		}
 		if ($this->default instanceof Schema) {

--- a/src/Schema/Elements/AnyOf.php
+++ b/src/Schema/Elements/AnyOf.php
@@ -75,6 +75,7 @@ final class AnyOf implements Schema
 				$dolly->path = $context->path;
 				$res = $item->complete($value, $dolly);
 				if (!$dolly->errors) {
+					$context->warnings = array_merge($context->warnings, $dolly->warnings);
 					return $this->doFinalize($res, $context);
 				}
 				foreach ($dolly->errors as $error) {

--- a/src/Schema/Elements/AnyOf.php
+++ b/src/Schema/Elements/AnyOf.php
@@ -68,7 +68,7 @@ final class AnyOf implements Schema
 
 	public function complete($value, Nette\Schema\Context $context)
 	{
-		$hints = $innerErrors = [];
+		$expecteds = $innerErrors = [];
 		foreach ($this->set as $item) {
 			if ($item instanceof Schema) {
 				$dolly = new Context;
@@ -78,25 +78,25 @@ final class AnyOf implements Schema
 					return $this->doFinalize($res, $context);
 				}
 				foreach ($dolly->errors as $error) {
-					if ($error->path !== $context->path || !$error->hint) {
+					if ($error->path !== $context->path || !$error->expected) {
 						$innerErrors[] = $error;
 					} else {
-						$hints[] = $error->hint;
+						$expecteds[] = $error->expected;
 					}
 				}
 			} else {
 				if ($item === $value) {
 					return $this->doFinalize($value, $context);
 				}
-				$hints[] = static::formatValue($item);
+				$expecteds[] = static::formatValue($item);
 			}
 		}
 
 		if ($innerErrors) {
 			$context->errors = array_merge($context->errors, $innerErrors);
 		} else {
-			$hints = implode('|', array_unique($hints));
-			$context->addError("The option %path% expects to be $hints, " . static::formatValue($value) . ' given.');
+			$expecteds = implode('|', array_unique($expecteds));
+			$context->addError("The option %path% expects to be $expecteds, " . static::formatValue($value) . ' given.');
 		}
 	}
 

--- a/src/Schema/Elements/Base.php
+++ b/src/Schema/Elements/Base.php
@@ -33,6 +33,9 @@ trait Base
 	/** @var string|null */
 	private $castTo;
 
+	/** @var string|null */
+	private $deprecated;
+
 
 	public function default($value): self
 	{
@@ -69,6 +72,14 @@ trait Base
 	}
 
 
+	/** Marks option as deprecated */
+	public function deprecated(string $message = 'Option %path% is deprecated.'): self
+	{
+		$this->deprecated = $message;
+		return $this;
+	}
+
+
 	public function completeDefault(Context $context)
 	{
 		if ($this->required) {
@@ -95,7 +106,6 @@ trait Base
 	{
 		try {
 			Nette\Utils\Validators::assert($value, $expected, 'option %path%');
-			return true;
 		} catch (Nette\Utils\AssertionException $e) {
 			$context->addError(
 				$e->getMessage(),
@@ -104,6 +114,14 @@ trait Base
 			);
 			return false;
 		}
+
+		if ($this->deprecated !== null) {
+			$context->addWarning(
+				$this->deprecated,
+				Nette\Schema\Message::DEPRECATED
+			);
+		}
+		return true;
 	}
 
 

--- a/src/Schema/Elements/Base.php
+++ b/src/Schema/Elements/Base.php
@@ -100,7 +100,7 @@ trait Base
 			$context->addError(
 				$e->getMessage(),
 				Nette\Schema\Message::UNEXPECTED_VALUE,
-				$expected
+				['value' => $value, 'expected' => $expected]
 			);
 			return false;
 		}
@@ -121,27 +121,14 @@ trait Base
 			if (!$handler($value)) {
 				$expected = $description ? ('"' . $description . '"') : (is_string($handler) ? "$handler()" : "#$i");
 				$context->addError(
-					"Failed assertion $expected for option %path% with value " . static::formatValue($value) . '.',
-					Nette\Schema\Message::FAILED_ASSERTION
+					'Failed assertion %assertion% for option %path% with value %value%.',
+					Nette\Schema\Message::FAILED_ASSERTION,
+					['value' => $value, 'assertion' => $expected]
 				);
 				return;
 			}
 		}
 
 		return $value;
-	}
-
-
-	private static function formatValue($value): string
-	{
-		if (is_string($value)) {
-			return "'$value'";
-		} elseif (is_bool($value)) {
-			return $value ? 'true' : 'false';
-		} elseif (is_scalar($value)) {
-			return (string) $value;
-		} else {
-			return strtolower(gettype($value));
-		}
 	}
 }

--- a/src/Schema/Elements/Base.php
+++ b/src/Schema/Elements/Base.php
@@ -72,7 +72,10 @@ trait Base
 	public function completeDefault(Context $context)
 	{
 		if ($this->required) {
-			$context->addError('The mandatory option %path% is missing.');
+			$context->addError(
+				'The mandatory option %path% is missing.',
+				Nette\Schema\Message::OPTION_MISSING
+			);
 			return null;
 		}
 		return $this->default;
@@ -94,7 +97,11 @@ trait Base
 			Nette\Utils\Validators::assert($value, $expected, 'option %path%');
 			return true;
 		} catch (Nette\Utils\AssertionException $e) {
-			$context->addError($e->getMessage(), $expected);
+			$context->addError(
+				$e->getMessage(),
+				Nette\Schema\Message::UNEXPECTED_VALUE,
+				$expected
+			);
 			return false;
 		}
 	}
@@ -113,7 +120,10 @@ trait Base
 		foreach ($this->asserts as $i => [$handler, $description]) {
 			if (!$handler($value)) {
 				$expected = $description ? ('"' . $description . '"') : (is_string($handler) ? "$handler()" : "#$i");
-				$context->addError("Failed assertion $expected for option %path% with value " . static::formatValue($value) . '.');
+				$context->addError(
+					"Failed assertion $expected for option %path% with value " . static::formatValue($value) . '.',
+					Nette\Schema\Message::FAILED_ASSERTION
+				);
 				return;
 			}
 		}

--- a/src/Schema/Elements/Structure.php
+++ b/src/Schema/Elements/Structure.php
@@ -146,7 +146,8 @@ final class Structure implements Schema
 				}, $hint ? [$extraKeys[0]] : $extraKeys));
 				$context->addError(
 					"Unexpected option '$s'" . ($hint ? ", did you mean '$hint'?" : '.'),
-					Nette\Schema\Message::UNEXPECTED_KEY
+					Nette\Schema\Message::UNEXPECTED_KEY,
+					['hint' => $hint]
 				);
 			}
 		}

--- a/src/Schema/Elements/Structure.php
+++ b/src/Schema/Elements/Structure.php
@@ -140,15 +140,15 @@ final class Structure implements Schema
 			if ($this->otherItems) {
 				$items += array_fill_keys($extraKeys, $this->otherItems);
 			} else {
-				$hint = Nette\Utils\Helpers::getSuggestion(array_map('strval', array_keys($items)), (string) $extraKeys[0]);
-				$s = implode("', '", array_map(function ($key) use ($context) {
-					return implode(' › ', array_merge($context->path, [$key]));
-				}, $hint ? [$extraKeys[0]] : $extraKeys));
-				$context->addError(
-					"Unexpected option '$s'" . ($hint ? ", did you mean '$hint'?" : '.'),
-					Nette\Schema\Message::UNEXPECTED_KEY,
-					['hint' => $hint]
-				);
+				$keys = array_map('strval', array_keys($items));
+				foreach ($extraKeys as $key) {
+					$hint = Nette\Utils\Helpers::getSuggestion($keys, (string) $key);
+					$context->addError(
+						'Unexpected option %path%' . ($hint ? ", did you mean '%hint%'?" : '.'),
+						Nette\Schema\Message::UNEXPECTED_KEY,
+						['hint' => $hint]
+					)->path[] = $key;
+				}
 			}
 		}
 

--- a/src/Schema/Elements/Structure.php
+++ b/src/Schema/Elements/Structure.php
@@ -144,7 +144,10 @@ final class Structure implements Schema
 				$s = implode("', '", array_map(function ($key) use ($context) {
 					return implode(' › ', array_merge($context->path, [$key]));
 				}, $hint ? [$extraKeys[0]] : $extraKeys));
-				$context->addError("Unexpected option '$s'" . ($hint ? ", did you mean '$hint'?" : '.'));
+				$context->addError(
+					"Unexpected option '$s'" . ($hint ? ", did you mean '$hint'?" : '.'),
+					Nette\Schema\Message::UNEXPECTED_KEY
+				);
 			}
 		}
 

--- a/src/Schema/Elements/Type.php
+++ b/src/Schema/Elements/Type.php
@@ -72,6 +72,7 @@ final class Type implements Schema
 
 	/**
 	 * @param  string|Schema  $type
+	 * @internal  use arrayOf() or listOf()
 	 */
 	public function items($type = 'mixed'): self
 	{

--- a/src/Schema/Elements/Type.php
+++ b/src/Schema/Elements/Type.php
@@ -165,7 +165,10 @@ final class Type implements Schema
 			}
 		}
 
-		$value = Helpers::merge($value, $this->default);
+		if (!is_array($value) || $value === []) {
+			$value = Helpers::merge($value, $this->default);
+		}
+
 		return $this->doFinalize($value, $context);
 	}
 }

--- a/src/Schema/Elements/Type.php
+++ b/src/Schema/Elements/Type.php
@@ -142,8 +142,9 @@ final class Type implements Schema
 		}
 		if ($this->pattern !== null && !preg_match("\x01^(?:$this->pattern)$\x01Du", $value)) {
 			$context->addError(
-				"The option %path% expects to match pattern '$this->pattern', '$value' given.",
-				Nette\Schema\Message::PATTERN_MISMATCH
+				"The option %path% expects to match pattern '%pattern%', %value% given.",
+				Nette\Schema\Message::PATTERN_MISMATCH,
+				['value' => $value, 'pattern' => $this->pattern]
 			);
 			return;
 		}

--- a/src/Schema/Elements/Type.php
+++ b/src/Schema/Elements/Type.php
@@ -141,7 +141,10 @@ final class Type implements Schema
 			return;
 		}
 		if ($this->pattern !== null && !preg_match("\x01^(?:$this->pattern)$\x01Du", $value)) {
-			$context->addError("The option %path% expects to match pattern '$this->pattern', '$value' given.");
+			$context->addError(
+				"The option %path% expects to match pattern '$this->pattern', '$value' given.",
+				Nette\Schema\Message::PATTERN_MISMATCH
+			);
 			return;
 		}
 

--- a/src/Schema/Message.php
+++ b/src/Schema/Message.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (https://nette.org)
+ * Copyright (c) 2004 David Grudl (https://davidgrudl.com)
+ */
+
+declare(strict_types=1);
+
+namespace Nette\Schema;
+
+use Nette;
+
+
+final class Message
+{
+	use Nette\SmartObject;
+
+	/** @var string */
+	public $message;
+
+	/** @var string[] */
+	public $path;
+
+	/** @var string[] */
+	public $variables;
+
+
+	public function __construct(string $message, array $path, array $variables = [])
+	{
+		$this->message = $message;
+		$this->path = $path;
+		$this->variables = $variables;
+	}
+
+
+	public function toString(): string
+	{
+		$pathStr = " '" . implode(' › ', $this->path) . "'";
+		return str_replace(' %path%', $this->path ? $pathStr : '', $this->message);
+	}
+}

--- a/src/Schema/Message.php
+++ b/src/Schema/Message.php
@@ -31,6 +31,9 @@ final class Message
 	/** variables: {hint: string} */
 	public const UNEXPECTED_KEY = 'schema.unexpectedKey';
 
+	/** no variables */
+	public const DEPRECATED = 'schema.deprecated';
+
 	/** @var string */
 	public $message;
 

--- a/src/Schema/Message.php
+++ b/src/Schema/Message.php
@@ -16,8 +16,21 @@ final class Message
 {
 	use Nette\SmartObject;
 
+	public const OPTION_MISSING = 'schema.optionMissing';
+
+	public const PATTERN_MISMATCH = 'schema.patternMismatch';
+
+	public const UNEXPECTED_VALUE = 'schema.unexpectedValue';
+
+	public const FAILED_ASSERTION = 'schema.failedAssertion';
+
+	public const UNEXPECTED_KEY = 'schema.unexpectedKey';
+
 	/** @var string */
 	public $message;
+
+	/** @var string */
+	public $code;
 
 	/** @var string[] */
 	public $path;
@@ -26,9 +39,10 @@ final class Message
 	public $variables;
 
 
-	public function __construct(string $message, array $path, array $variables = [])
+	public function __construct(string $message, string $code, array $path, array $variables = [])
 	{
 		$this->message = $message;
+		$this->code = $code;
 		$this->path = $path;
 		$this->variables = $variables;
 	}

--- a/src/Schema/Message.php
+++ b/src/Schema/Message.php
@@ -16,14 +16,19 @@ final class Message
 {
 	use Nette\SmartObject;
 
+	/** no variables */
 	public const OPTION_MISSING = 'schema.optionMissing';
 
+	/** variables: {value: string, pattern: string} */
 	public const PATTERN_MISMATCH = 'schema.patternMismatch';
 
+	/** variables: {value: mixed, expected: string} */
 	public const UNEXPECTED_VALUE = 'schema.unexpectedValue';
 
+	/** variables: {value: mixed, assertion: string} */
 	public const FAILED_ASSERTION = 'schema.failedAssertion';
 
+	/** variables: {hint: string} */
 	public const UNEXPECTED_KEY = 'schema.unexpectedKey';
 
 	/** @var string */
@@ -50,7 +55,27 @@ final class Message
 
 	public function toString(): string
 	{
-		$pathStr = " '" . implode(' › ', $this->path) . "'";
-		return str_replace(' %path%', $this->path ? $pathStr : '', $this->message);
+		$vars = $this->variables;
+		$vars['path'] = $this->path ? "'" . implode(' › ', $this->path) . "'" : null;
+		$vars['value'] = self::formatValue($vars['value'] ?? null);
+
+		return preg_replace_callback('~( ?)%(\w+)%~', function ($m) use ($vars) {
+			[, $space, $key] = $m;
+			return $vars[$key] === null ? '' : $space . $vars[$key];
+		}, $this->message);
+	}
+
+
+	public static function formatValue($value): string
+	{
+		if (is_string($value)) {
+			return "'$value'";
+		} elseif (is_bool($value)) {
+			return $value ? 'true' : 'false';
+		} elseif (is_scalar($value)) {
+			return (string) $value;
+		} else {
+			return strtolower(gettype($value));
+		}
 	}
 }

--- a/src/Schema/Processor.php
+++ b/src/Schema/Processor.php
@@ -72,12 +72,8 @@ final class Processor
 
 	private function throwsErrors(Context $context): void
 	{
-		$messages = [];
-		foreach ($context->errors as $error) {
-			$messages[] = $error->toString();
-		}
-		if ($messages) {
-			throw new ValidationException($messages[0], $messages);
+		if ($context->errors) {
+			throw new ValidationException(null, $context->errors);
 		}
 	}
 

--- a/src/Schema/Processor.php
+++ b/src/Schema/Processor.php
@@ -22,6 +22,9 @@ final class Processor
 	/** @var array */
 	public $onNewContext = [];
 
+	/** @var Context|null */
+	private $context;
+
 	/** @var bool */
 	private $skipDefaults;
 
@@ -39,11 +42,11 @@ final class Processor
 	 */
 	public function process(Schema $schema, $data)
 	{
-		$context = $this->createContext();
-		$data = $schema->normalize($data, $context);
-		$this->throwsErrors($context);
-		$data = $schema->complete($data, $context);
-		$this->throwsErrors($context);
+		$this->createContext();
+		$data = $schema->normalize($data, $this->context);
+		$this->throwsErrors();
+		$data = $schema->complete($data, $this->context);
+		$this->throwsErrors();
 		return $data;
 	}
 
@@ -55,34 +58,33 @@ final class Processor
 	 */
 	public function processMultiple(Schema $schema, array $dataset)
 	{
-		$context = $this->createContext();
+		$this->createContext();
 		$flatten = null;
 		$first = true;
 		foreach ($dataset as $data) {
-			$data = $schema->normalize($data, $context);
-			$this->throwsErrors($context);
+			$data = $schema->normalize($data, $this->context);
+			$this->throwsErrors();
 			$flatten = $first ? $data : $schema->merge($data, $flatten);
 			$first = false;
 		}
-		$data = $schema->complete($flatten, $context);
-		$this->throwsErrors($context);
+		$data = $schema->complete($flatten, $this->context);
+		$this->throwsErrors();
 		return $data;
 	}
 
 
-	private function throwsErrors(Context $context): void
+	private function throwsErrors(): void
 	{
-		if ($context->errors) {
-			throw new ValidationException(null, $context->errors);
+		if ($this->context->errors) {
+			throw new ValidationException(null, $this->context->errors);
 		}
 	}
 
 
-	private function createContext(): Context
+	private function createContext()
 	{
-		$context = new Context;
-		$context->skipDefaults = $this->skipDefaults;
-		$this->onNewContext($context);
-		return $context;
+		$this->context = new Context;
+		$this->context->skipDefaults = $this->skipDefaults;
+		$this->onNewContext($this->context);
 	}
 }

--- a/src/Schema/Processor.php
+++ b/src/Schema/Processor.php
@@ -74,8 +74,7 @@ final class Processor
 	{
 		$messages = [];
 		foreach ($context->errors as $error) {
-			$pathStr = " '" . implode(' › ', $error->path) . "'";
-			$messages[] = str_replace(' %path%', $error->path ? $pathStr : '', $error->message);
+			$messages[] = $error->toString();
 		}
 		if ($messages) {
 			throw new ValidationException($messages[0], $messages);

--- a/src/Schema/Processor.php
+++ b/src/Schema/Processor.php
@@ -73,6 +73,19 @@ final class Processor
 	}
 
 
+	/**
+	 * @return string[]
+	 */
+	public function getWarnings(): array
+	{
+		$res = [];
+		foreach ($this->context->warnings as $message) {
+			$res[] = $message->toString();
+		}
+		return $res;
+	}
+
+
 	private function throwsErrors(): void
 	{
 		if ($this->context->errors) {

--- a/src/Schema/ValidationException.php
+++ b/src/Schema/ValidationException.php
@@ -17,18 +17,37 @@ use Nette;
  */
 class ValidationException extends Nette\InvalidStateException
 {
-	/** @var array */
+	/** @var Message[] */
 	private $messages;
 
 
-	public function __construct(string $message, array $messages = [])
+	/**
+	 * @param  Message[]  $messages
+	 */
+	public function __construct(?string $message, array $messages = [])
 	{
-		parent::__construct($message);
-		$this->messages = $messages ?: [$message];
+		parent::__construct($message ?: $messages[0]->toString());
+		$this->messages = $messages;
 	}
 
 
+	/**
+	 * @return string[]
+	 */
 	public function getMessages(): array
+	{
+		$res = [];
+		foreach ($this->messages as $message) {
+			$res[] = $message->toString();
+		}
+		return $res;
+	}
+
+
+	/**
+	 * @return Message[]
+	 */
+	public function getMessageObjects(): array
 	{
 		return $this->messages;
 	}

--- a/tests/Schema/Expect.anyOf.phpt
+++ b/tests/Schema/Expect.anyOf.phpt
@@ -10,7 +10,7 @@ use Tester\Assert;
 require __DIR__ . '/../bootstrap.php';
 
 
-test(function () { // with scalars
+test('with scalars', function () {
 	$schema = Expect::anyOf('one', true, Expect::int());
 
 	Assert::same('one', (new Processor)->process($schema, 'one'));
@@ -37,7 +37,7 @@ test(function () { // with scalars
 });
 
 
-test(function () { // with complex structure
+test('with complex structure', function () {
 	$schema = Expect::anyOf(Expect::listOf('string'), true, Expect::int());
 
 	checkValidationErrors(function () use ($schema) {
@@ -52,7 +52,7 @@ test(function () { // with complex structure
 });
 
 
-test(function () { // with asserts
+test('with asserts', function () {
 	$schema = Expect::anyOf(Expect::string()->assert('strlen'), true);
 
 	checkValidationErrors(function () use ($schema) {
@@ -67,7 +67,7 @@ test(function () { // with asserts
 });
 
 
-test(function () { // no default value
+test('no default value', function () {
 	$schema = Expect::structure([
 		'key1' => Expect::anyOf(Expect::string(), Expect::int()),
 		'key2' => Expect::anyOf(Expect::string('default'), true, Expect::int()),
@@ -81,7 +81,7 @@ test(function () { // no default value
 });
 
 
-test(function () { // required
+test('required', function () {
 	$schema = Expect::structure([
 		'key1' => Expect::anyOf(Expect::string(), Expect::int())->required(),
 		'key2' => Expect::anyOf(Expect::string('default'), true, Expect::int())->required(),
@@ -102,7 +102,7 @@ test(function () { // required
 });
 
 
-test(function () { // required as argument
+test('required as argument', function () {
 	$schema = Expect::structure([
 		'key1' => Expect::anyOf(Expect::string(), Expect::int())->required(),
 		'key1nr' => Expect::anyOf(Expect::string(), Expect::int())->required(false),
@@ -128,7 +128,7 @@ test(function () { // required as argument
 });
 
 
-test(function () { // not nullable
+test('not nullable', function () {
 	$schema = Expect::structure([
 		'key1' => Expect::anyOf(Expect::string(), Expect::int()),
 		'key2' => Expect::anyOf(Expect::string('default'), true, Expect::int()),
@@ -145,7 +145,7 @@ test(function () { // not nullable
 });
 
 
-test(function () { // required & nullable
+test('required & nullable', function () {
 	$schema = Expect::structure([
 		'key1' => Expect::anyOf(Expect::string()->nullable(), Expect::int())->required(),
 		'key2' => Expect::anyOf(Expect::string('default'), true, Expect::int(), null)->required(),
@@ -159,7 +159,7 @@ test(function () { // required & nullable
 });
 
 
-test(function () { // nullable anyOf
+test('nullable anyOf', function () {
 	$schema = Expect::anyOf(Expect::string(), true)->nullable();
 
 	Assert::same('one', (new Processor)->process($schema, 'one'));
@@ -172,7 +172,7 @@ test(function () { // nullable anyOf
 });
 
 
-test(function () { // processing
+test('processing', function () {
 	$schema = Expect::anyOf(Expect::string(), true)->nullable();
 	$processor = new Processor;
 
@@ -189,7 +189,7 @@ test(function () { // processing
 });
 
 
-test(function () { // Schema as default value
+test('Schema as default value', function () {
 	$default = Expect::structure([
 		'key2' => Expect::string(),
 	])->castTo('array');

--- a/tests/Schema/Expect.anyOf.phpt
+++ b/tests/Schema/Expect.anyOf.phpt
@@ -159,6 +159,21 @@ test('required & nullable', function () {
 });
 
 
+test('deprecated item', function () {
+	$schema = Expect::anyOf('one', true, Expect::int()->deprecated());
+
+	$processor = new Processor;
+	Assert::same('one', $processor->process($schema, 'one'));
+	Assert::same([], $processor->getWarnings());
+
+	Assert::same(true, $processor->process($schema, true));
+	Assert::same([], $processor->getWarnings());
+
+	Assert::same(123, $processor->process($schema, 123));
+	Assert::same(['Option is deprecated.'], $processor->getWarnings());
+});
+
+
 test('nullable anyOf', function () {
 	$schema = Expect::anyOf(Expect::string(), true)->nullable();
 

--- a/tests/Schema/Expect.array.phpt
+++ b/tests/Schema/Expect.array.phpt
@@ -10,7 +10,7 @@ use Tester\Assert;
 require __DIR__ . '/../bootstrap.php';
 
 
-test(function () { // without default value
+test('without default value', function () {
 	$schema = Expect::array();
 
 	Assert::same([], (new Processor)->process($schema, []));
@@ -35,7 +35,7 @@ test(function () { // without default value
 });
 
 
-test(function () { // merging
+test('merging', function () {
 	$schema = Expect::array([
 		'key1' => 'val1',
 		'key2' => 'val2',
@@ -77,7 +77,7 @@ test(function () { // merging
 });
 
 
-test(function () { // merging & other items validation
+test('merging & other items validation', function () {
 	$schema = Expect::array([
 		'key1' => 'val1',
 		'key2' => 'val2',
@@ -114,7 +114,7 @@ test(function () { // merging & other items validation
 });
 
 
-test(function () { // merging & other items validation
+test('merging & other items validation', function () {
 	$schema = Expect::array()->items('string');
 
 	Assert::same([
@@ -147,7 +147,7 @@ test(function () { // merging & other items validation
 });
 
 
-test(function () { // items() & scalar
+test('items() & scalar', function () {
 	$schema = Expect::array([
 		'a' => 'defval',
 	])->items('string');
@@ -180,7 +180,7 @@ test(function () { // items() & scalar
 });
 
 
-test(function () { // items() & structure
+test('items() & structure', function () {
 	$schema = Expect::array([
 		'a' => 'defval',
 	])->items(Expect::structure(['k' => Expect::string()]));
@@ -214,7 +214,7 @@ test(function () { // items() & structure
 });
 
 
-test(function () { // arrayOf() & scalar
+test('arrayOf() & scalar', function () {
 	$schema = Expect::arrayOf('string|int');
 
 	Assert::same([], (new Processor)->process($schema, []));
@@ -231,14 +231,14 @@ test(function () { // arrayOf() & scalar
 });
 
 
-test(function () { // arrayOf() error
+test('arrayOf() error', function () {
 	Assert::exception(function () {
 		Expect::arrayOf(['a' => Expect::string()]);
 	}, TypeError::class);
 });
 
 
-test(function () { // type[]
+test('type[]', function () {
 	$schema = Expect::type('int[]');
 
 	Assert::same([], (new Processor)->process($schema, null));

--- a/tests/Schema/Expect.array.phpt
+++ b/tests/Schema/Expect.array.phpt
@@ -51,22 +51,13 @@ test('merging', function () {
 	], (new Processor)->process($schema, []));
 
 	Assert::same([
-			'key1' => 'val1',
-			'key2' => 'val2',
-			'val3',
-			'arr' => ['item'],
-			1, 2, 3,
-		],
-		(new Processor)->process($schema, [1, 2, 3])
-	);
+		1, 2, 3,
+	], (new Processor)->process($schema, [1, 2, 3]));
 
 	Assert::same([
 			'key1' => 'newval',
-			'key2' => 'val2',
-			'val3',
-			'arr' => ['item', 'newitem'],
 			'key3' => 'newval',
-			'newval3',
+			'newval3', 'arr' => ['newitem'],
 		],
 		(new Processor)->process($schema, [
 			'key1' => 'newval',
@@ -100,8 +91,6 @@ test('merging & other items validation', function () {
 
 	Assert::same([
 			'key1' => 'newval',
-			'key2' => 'val2',
-			'val3',
 			'key3' => 'newval',
 			'newval3',
 		],
@@ -176,7 +165,7 @@ test('items() & scalar', function () {
 		(new Processor)->process($schema, ['b' => null]);
 	}, ["The option 'b' expects to be string, null given."]);
 
-	Assert::same(['a' => 'defval', 'b' => 'val'], (new Processor)->process($schema, ['b' => 'val']));
+	Assert::same(['b' => 'val'], (new Processor)->process($schema, ['b' => 'val']));
 });
 
 
@@ -208,7 +197,7 @@ test('items() & structure', function () {
 	}, ["Unexpected option 'b › a', did you mean 'k'?"]);
 
 	Assert::equal(
-		['a' => 'defval', 'b' => (object) ['k' => 'val']],
+		['b' => (object) ['k' => 'val']],
 		(new Processor)->process($schema, ['b' => ['k' => 'val']])
 	);
 });

--- a/tests/Schema/Expect.assert.phpt
+++ b/tests/Schema/Expect.assert.phpt
@@ -10,7 +10,7 @@ use Tester\Assert;
 require __DIR__ . '/../bootstrap.php';
 
 
-test(function () { // single assertion
+test('single assertion', function () {
 	$schema = Expect::string()->assert('is_file');
 
 	checkValidationErrors(function () use ($schema) {
@@ -21,7 +21,7 @@ test(function () { // single assertion
 });
 
 
-test(function () { // multiple assertions
+test('multiple assertions', function () {
 	$schema = Expect::string()->assert('ctype_digit')->assert(function ($s) { return strlen($s) >= 3; });
 
 	checkValidationErrors(function () use ($schema) {
@@ -36,7 +36,7 @@ test(function () { // multiple assertions
 });
 
 
-test(function () { // multiple assertions with custom descriptions
+test('multiple assertions with custom descriptions', function () {
 	$schema = Expect::string()
 		->assert('ctype_digit', 'Is number')
 		->assert(function ($s) { return strlen($s) >= 3; }, 'Minimal lenght');

--- a/tests/Schema/Expect.before.phpt
+++ b/tests/Schema/Expect.before.phpt
@@ -10,7 +10,7 @@ use Tester\Assert;
 require __DIR__ . '/../bootstrap.php';
 
 
-test(function () {
+test('', function () {
 	$schema = Expect::array()
 		->before(function ($val) { return explode(',', $val); });
 
@@ -21,7 +21,7 @@ test(function () {
 });
 
 
-test(function () { // structure property
+test('structure property', function () {
 	$schema = Expect::structure([
 		'key' => Expect::string()->before('strrev'),
 	]);
@@ -33,7 +33,7 @@ test(function () { // structure property
 });
 
 
-test(function () { // order in structure
+test('order in structure', function () {
 	$schema = Expect::structure([
 		'a' => Expect::string()->before(function ($val) use (&$order) { $order[] = 'a'; return $val; }),
 		'b' => Expect::string()->before(function ($val) use (&$order) { $order[] = 'b'; return $val; }),
@@ -63,7 +63,7 @@ test(function () { // order in structure
 });
 
 
-test(function () { // order in array
+test('order in array', function () {
 	$schema = Expect::array()
 		->items(Expect::string()->before(function ($val) use (&$order) { $order[] = 'item'; return $val; }))
 		->before(function ($val) use (&$order) { $order[] = 'array'; return $val; });

--- a/tests/Schema/Expect.castTo.phpt
+++ b/tests/Schema/Expect.castTo.phpt
@@ -10,21 +10,21 @@ use Tester\Assert;
 require __DIR__ . '/../bootstrap.php';
 
 
-test(function () {
+test('', function () {
 	$schema = Expect::int()->castTo('string');
 
 	Assert::same('10', (new Processor)->process($schema, 10));
 });
 
 
-test(function () {
+test('', function () {
 	$schema = Expect::string()->castTo('array');
 
 	Assert::same(['foo'], (new Processor)->process($schema, 'foo'));
 });
 
 
-test(function () {
+test('', function () {
 	$schema = Expect::array()->castTo('stdClass');
 
 	Assert::equal((object) ['a' => 1, 'b' => 2], (new Processor)->process($schema, ['a' => 1, 'b' => 2]));

--- a/tests/Schema/Expect.dynamic.phpt
+++ b/tests/Schema/Expect.dynamic.phpt
@@ -23,7 +23,7 @@ class DynamicParameter implements Nette\Schema\DynamicParameter
 }
 
 
-test(function () {
+test('', function () {
 	$schema = Expect::structure([
 		'a' => Expect::string()->dynamic(),
 		'b' => Expect::string('def')->dynamic(),

--- a/tests/Schema/Expect.list.phpt
+++ b/tests/Schema/Expect.list.phpt
@@ -10,7 +10,7 @@ use Tester\Assert;
 require __DIR__ . '/../bootstrap.php';
 
 
-test(function () { // without default value
+test('without default value', function () {
 	$schema = Expect::list();
 
 	Assert::same([], (new Processor)->process($schema, []));
@@ -37,7 +37,7 @@ test(function () { // without default value
 });
 
 
-test(function () { // merging
+test('merging', function () {
 	$schema = Expect::list([1, 2, 3]);
 
 	Assert::same([1, 2, 3], (new Processor)->process($schema, []));
@@ -48,7 +48,7 @@ test(function () { // merging
 });
 
 
-test(function () { // merging & other items validation
+test('merging & other items validation', function () {
 	$schema = Expect::list([1, 2, 3])->items('string');
 
 	Assert::same([1, 2, 3], (new Processor)->process($schema, []));
@@ -67,7 +67,7 @@ test(function () { // merging & other items validation
 });
 
 
-test(function () { // listOf() & scalar
+test('listOf() & scalar', function () {
 	$schema = Expect::listOf('string');
 
 	Assert::same([], (new Processor)->process($schema, []));
@@ -88,7 +88,7 @@ test(function () { // listOf() & scalar
 });
 
 
-test(function () { // listOf() & error
+test('listOf() & error', function () {
 	Assert::exception(function () {
 		Expect::listOf(['a' => Expect::string()]);
 	}, TypeError::class);

--- a/tests/Schema/Expect.list.phpt
+++ b/tests/Schema/Expect.list.phpt
@@ -42,7 +42,7 @@ test('merging', function () {
 
 	Assert::same([1, 2, 3], (new Processor)->process($schema, []));
 
-	Assert::same([1, 2, 3, 'a', 'b', 'c'], (new Processor)->process($schema, ['a', 'b', 'c']));
+	Assert::same(['a', 'b', 'c'], (new Processor)->process($schema, ['a', 'b', 'c']));
 
 	Assert::same([1, 2, 3], (new Processor)->process($schema, null));
 });
@@ -53,7 +53,7 @@ test('merging & other items validation', function () {
 
 	Assert::same([1, 2, 3], (new Processor)->process($schema, []));
 
-	Assert::same([1, 2, 3, 'a', 'b', 'c'], (new Processor)->process($schema, ['a', 'b', 'c']));
+	Assert::same(['a', 'b', 'c'], (new Processor)->process($schema, ['a', 'b', 'c']));
 
 	checkValidationErrors(function () use ($schema) {
 		(new Processor)->process($schema, [1, 2, 3]);

--- a/tests/Schema/Expect.minmax.phpt
+++ b/tests/Schema/Expect.minmax.phpt
@@ -10,7 +10,7 @@ use Tester\Assert;
 require __DIR__ . '/../bootstrap.php';
 
 
-test(function () { // int & min
+test('int & min', function () {
 	$schema = Expect::int()->min(10);
 
 	Assert::same(10, (new Processor)->process($schema, 10));
@@ -21,7 +21,7 @@ test(function () { // int & min
 });
 
 
-test(function () { // int & max
+test('int & max', function () {
 	$schema = Expect::int()->max(20);
 
 	Assert::same(20, (new Processor)->process($schema, 20));
@@ -32,7 +32,7 @@ test(function () { // int & max
 });
 
 
-test(function () { // int & min & max
+test('int & min & max', function () {
 	$schema = Expect::int()->min(10)->max(20);
 
 	Assert::same(10, (new Processor)->process($schema, 10));
@@ -48,7 +48,7 @@ test(function () { // int & min & max
 });
 
 
-test(function () { // string
+test('string', function () {
 	$schema = Expect::string()->min(1)->max(5);
 
 	Assert::same('hello', (new Processor)->process($schema, 'hello'));
@@ -64,7 +64,7 @@ test(function () { // string
 });
 
 
-test(function () { // array
+test('array', function () {
 	$schema = Expect::array()->min(1)->max(3);
 
 	Assert::same([1], (new Processor)->process($schema, [1]));
@@ -80,7 +80,7 @@ test(function () { // array
 });
 
 
-test(function () { // structure
+test('structure', function () {
 	$schema = Expect::structure([])->otherItems('int')->min(1)->max(3);
 
 	Assert::equal((object) [1], (new Processor)->process($schema, [1]));

--- a/tests/Schema/Expect.pattern.phpt
+++ b/tests/Schema/Expect.pattern.phpt
@@ -10,14 +10,14 @@ use Tester\Assert;
 require __DIR__ . '/../bootstrap.php';
 
 
-test(function () {
+test('', function () {
 	$schema = Expect::string()->pattern('\d{9}');
 
 	Assert::same('123456789', (new Processor)->process($schema, '123456789'));
 });
 
 
-test(function () {
+test('', function () {
 	$schema = Expect::string()->pattern('\d{9}');
 
 	checkValidationErrors(function () use ($schema) {

--- a/tests/Schema/Expect.scalars.phpt
+++ b/tests/Schema/Expect.scalars.phpt
@@ -10,7 +10,7 @@ use Tester\Assert;
 require __DIR__ . '/../bootstrap.php';
 
 
-test(function () {
+test('', function () {
 	$schema = Expect::scalar();
 
 	Assert::same('hello', (new Processor)->process($schema, 'hello'));
@@ -27,7 +27,7 @@ test(function () {
 });
 
 
-test(function () {
+test('', function () {
 	$schema = Expect::string();
 
 	Assert::same('hello', (new Processor)->process($schema, 'hello'));
@@ -50,7 +50,7 @@ test(function () {
 });
 
 
-test(function () {
+test('', function () {
 	$schema = Expect::type('string|bool');
 
 	Assert::same('one', (new Processor)->process($schema, 'one'));
@@ -71,7 +71,7 @@ test(function () {
 });
 
 
-test(function () {
+test('', function () {
 	$schema = Expect::type('string')->nullable();
 
 	Assert::same('one', (new Processor)->process($schema, 'one'));

--- a/tests/Schema/Expect.structure.phpt
+++ b/tests/Schema/Expect.structure.phpt
@@ -10,7 +10,7 @@ use Tester\Assert;
 require __DIR__ . '/../bootstrap.php';
 
 
-test(function () { // without items
+test('without items', function () {
 	$schema = Expect::structure([]);
 
 	Assert::equal((object) [], (new Processor)->process($schema, []));
@@ -39,7 +39,7 @@ test(function () { // without items
 });
 
 
-test(function () { // accepts object
+test('accepts object', function () {
 	$schema = Expect::structure(['a' => Expect::string()]);
 
 	Assert::equal((object) ['a' => null], (new Processor)->process($schema, (object) []));
@@ -61,7 +61,7 @@ test(function () { // accepts object
 });
 
 
-test(function () { // scalar items
+test('scalar items', function () {
 	$schema = Expect::structure([
 		'a' => Expect::string(),
 		'b' => Expect::int(),
@@ -82,7 +82,7 @@ test(function () { // scalar items
 });
 
 
-test(function () { // array items
+test('array items', function () {
 	$schema = Expect::structure([
 		'a' => Expect::array(),
 		'b' => Expect::array([]),
@@ -101,14 +101,14 @@ test(function () { // array items
 });
 
 
-test(function () { // default value must be readonly
+test('default value must be readonly', function () {
 	Assert::exception(function () {
 		$schema = Expect::structure([])->default([]);
 	}, Nette\InvalidStateException::class);
 });
 
 
-test(function () { // with indexed item
+test('with indexed item', function () {
 	$schema = Expect::structure([
 		'key1' => Expect::string(),
 		'key2' => Expect::string(),
@@ -161,7 +161,7 @@ test(function () { // with indexed item
 });
 
 
-test(function () { // with indexed item & otherItems
+test('with indexed item & otherItems', function () {
 	$schema = Expect::structure([
 		'key1' => Expect::string(),
 		'key2' => Expect::string(),
@@ -218,7 +218,7 @@ test(function () { // with indexed item & otherItems
 });
 
 
-test(function () { // item with default value
+test('item with default value', function () {
 	$schema = Expect::structure([
 		'b' => Expect::string(123),
 	]);
@@ -243,7 +243,7 @@ test(function () { // item with default value
 });
 
 
-test(function () { // item without default value
+test('item without default value', function () {
 	$schema = Expect::structure([
 		'b' => Expect::string(),
 	]);
@@ -262,7 +262,7 @@ test(function () { // item without default value
 });
 
 
-test(function () { // required item
+test('required item', function () {
 	$schema = Expect::structure([
 		'b' => Expect::string()->required(),
 		'c' => Expect::array()->required(),
@@ -286,7 +286,7 @@ test(function () { // required item
 });
 
 
-test(function () { // other items
+test('other items', function () {
 	$schema = Expect::structure([
 		'key' => Expect::string(),
 	])->otherItems(Expect::string());
@@ -300,7 +300,7 @@ test(function () { // other items
 });
 
 
-test(function () { // structure items
+test('structure items', function () {
 	$schema = Expect::structure([
 		'a' => Expect::structure([
 			'x' => Expect::string('defval'),
@@ -369,7 +369,7 @@ test(function () { // structure items
 });
 
 
-test(function () { // processing
+test('processing', function () {
 	$schema = Expect::structure([
 		'a' => Expect::structure([
 			'x' => Expect::string('defval'),
@@ -398,7 +398,7 @@ test(function () { // processing
 });
 
 
-test(function () { // processing without default values
+test('processing without default values', function () {
 	$schema = Expect::structure([
 		'a' => Expect::string(), // implicit default
 		'b' => Expect::string('hello'), // explicit default

--- a/tests/Schema/Expect.structure.phpt
+++ b/tests/Schema/Expect.structure.phpt
@@ -17,7 +17,7 @@ test('without items', function () {
 
 	checkValidationErrors(function () use ($schema) {
 		(new Processor)->process($schema, [1, 2, 3]);
-	}, ["Unexpected option '0', '1', '2'."]);
+	}, ["Unexpected option '0'.", "Unexpected option '1'.", "Unexpected option '2'."]);
 
 	checkValidationErrors(function () use ($schema) {
 		(new Processor)->process($schema, ['key' => 'val']);
@@ -141,7 +141,8 @@ test('with indexed item', function () {
 	checkValidationErrors(function () use ($processor, $schema) {
 		$processor->process($schema, [1, 2, 3]);
 	}, [
-		"Unexpected option '1', '2'.",
+		"Unexpected option '1'.",
+		"Unexpected option '2'.",
 		"The option '0' expects to be string, int 1 given.",
 	]);
 
@@ -227,7 +228,11 @@ test('item with default value', function () {
 
 	checkValidationErrors(function () use ($schema) {
 		(new Processor)->process($schema, [1, 2, 3]);
-	}, ["Unexpected option '0', did you mean 'b'?"]);
+	}, [
+		"Unexpected option '0', did you mean 'b'?",
+		"Unexpected option '1', did you mean 'b'?",
+		"Unexpected option '2', did you mean 'b'?",
+	]);
 
 	Assert::equal((object) ['b' => 123], (new Processor)->process($schema, []));
 
@@ -318,6 +323,8 @@ test('structure items', function () {
 		(new Processor)->process($schema, [1, 2, 3]);
 	}, [
 		"Unexpected option '0', did you mean 'a'?",
+		"Unexpected option '1', did you mean 'a'?",
+		"Unexpected option '2', did you mean 'a'?",
 		"The mandatory option 'b › y' is missing.",
 	]);
 
@@ -354,7 +361,8 @@ test('structure items', function () {
 	checkValidationErrors(function () use ($schema) {
 		(new Processor)->process($schema, ['b' => ['x1' => 'val', 'x2' => 'val']]);
 	}, [
-		"Unexpected option 'b › x1', 'b › x2'.",
+		"Unexpected option 'b › x1'.",
+		"Unexpected option 'b › x2'.",
 		"The mandatory option 'b › y' is missing.",
 	]);
 

--- a/tests/Schema/Expect.structure.phpt
+++ b/tests/Schema/Expect.structure.phpt
@@ -426,3 +426,31 @@ test('processing without default values', function () {
 		$processor->process($schema, ['d' => 'newval'])
 	);
 });
+
+
+test('deprecated item', function () {
+	$schema = Expect::structure([
+		'b' => Expect::string()->deprecated('depr %path%'),
+	]);
+
+	$processor = new Processor;
+	Assert::equal(
+		(object) ['b' => 'val'],
+		$processor->process($schema, ['b' => 'val'])
+	);
+	Assert::same(["depr 'b'"], $processor->getWarnings());
+});
+
+
+test('deprecated other items', function () {
+	$schema = Expect::structure([
+		'key' => Expect::string(),
+	])->otherItems(Expect::string()->deprecated());
+
+	$processor = new Processor;
+	Assert::equal((object) ['key' => null], $processor->process($schema, []));
+	Assert::same([], $processor->getWarnings());
+
+	Assert::equal((object) ['key' => null, 'other' => 'foo'], $processor->process($schema, ['other' => 'foo']));
+	Assert::same(["Option 'other' is deprecated."], $processor->getWarnings());
+});

--- a/tests/Schema/Processor.context.phpt
+++ b/tests/Schema/Processor.context.phpt
@@ -10,7 +10,7 @@ use Nette\Schema\Processor;
 require __DIR__ . '/../bootstrap.php';
 
 
-test(function () {
+test('', function () {
 	$schema = Expect::structure([
 		'r' => Expect::string()->required(),
 	]);

--- a/tests/Schema/Processor.context.phpt
+++ b/tests/Schema/Processor.context.phpt
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Nette\Schema\Context;
 use Nette\Schema\Expect;
 use Nette\Schema\Processor;
+use Tester\Assert;
 
 
 require __DIR__ . '/../bootstrap.php';
@@ -20,7 +21,18 @@ test('', function () {
 		$context->path = ['first'];
 	};
 
-	checkValidationErrors(function () use ($schema, $processor) {
+	$e = checkValidationErrors(function () use ($schema, $processor) {
 		$processor->process($schema, []);
 	}, ["The mandatory option 'first › r' is missing."]);
+
+	Assert::equal(
+		[
+			new Nette\Schema\Message(
+				'The mandatory option %path% is missing.',
+				['first', 'r'],
+				['expected' => null]
+			),
+		],
+		$e->getMessageObjects()
+	);
 });

--- a/tests/Schema/Processor.context.phpt
+++ b/tests/Schema/Processor.context.phpt
@@ -30,8 +30,7 @@ test('', function () {
 			new Nette\Schema\Message(
 				'The mandatory option %path% is missing.',
 				Nette\Schema\Message::OPTION_MISSING,
-				['first', 'r'],
-				['expected' => null]
+				['first', 'r']
 			),
 		],
 		$e->getMessageObjects()

--- a/tests/Schema/Processor.context.phpt
+++ b/tests/Schema/Processor.context.phpt
@@ -29,6 +29,7 @@ test('', function () {
 		[
 			new Nette\Schema\Message(
 				'The mandatory option %path% is missing.',
+				Nette\Schema\Message::OPTION_MISSING,
 				['first', 'r'],
 				['expected' => null]
 			),

--- a/tests/Schema/heterogenous.phpt
+++ b/tests/Schema/heterogenous.phpt
@@ -39,7 +39,7 @@ class MySchema implements Schema
 }
 
 
-test(function () {
+test('', function () {
 	$schema = Expect::arrayOf(new MySchema);
 	$processor = new Processor;
 
@@ -49,7 +49,7 @@ test(function () {
 });
 
 
-test(function () {
+test('', function () {
 	$schema = Expect::arrayOf(new MySchema);
 	$processor = new Processor;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -24,9 +24,10 @@ function test(string $title, Closure $function): void
 }
 
 
-function checkValidationErrors(\Closure $function, array $messages): void
+function checkValidationErrors(\Closure $function, array $messages): Nette\Schema\ValidationException
 {
 	$e = Assert::exception($function, Nette\Schema\ValidationException::class);
 	Assert::same($messages, $e->getMessages());
 	Assert::same($messages[0], $e->getMessage());
+	return $e;
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,7 +18,7 @@ Tester\Environment::setup();
 date_default_timezone_set('Europe/Prague');
 
 
-function test(\Closure $function): void
+function test(string $title, Closure $function): void
 {
 	$function();
 }


### PR DESCRIPTION
- bug fix / **new feature** (#13, #24, https://github.com/nette/schema/pull/28#issuecomment-712131718)
- BC break? **yes**
- doc PR: nette/docs#???  <!-- highly welcome, see https://nette.org/en/writing -->

This is an alternative to #28 which always prevents default array values from being merged with user-provided ones.