### PR TITLE
Expect: Fix method phpdoc

### DIFF
--- a/src/Schema/Expect.php
+++ b/src/Schema/Expect.php
@@ -27,6 +27,7 @@ use Nette\Schema\Elements\Type;
  * @method static Type array($default = [])
  * @method static Type list($default = [])
  * @method static Type mixed($default = null)
+ * @method static Type email($default = null)
  * @method static Type unicode($default = null)
  */
 final class Expect


### PR DESCRIPTION
- bug fix
- BC break? no
- doc PR: not needed

 `Expect::email()` method was removed from phpdoc in revision db05f011378849b2bce79daa70e0a62ab9d50dfb, this breaks previously working IDE completion and static analysis tools also complain. I assume this was a simple typo and the annotation should have stayed.