### PR TITLE
Add support for PHP 8.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: ['8.1', '8.2', '8.3', '8.4', '8.5']
+                php: ['8.1', '8.2', '8.3', '8.4', '8.5', '8.6']
 
             fail-fast: false
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ subtler than it looks.
 **Nette Schema** validates and normalizes data structures (config files, API
 inputs) through a fluent `Expect::` builder and a `Processor`.
 
-- **PHP Version**: 8.1 - 8.5
+- **PHP Version**: 8.1 - 8.6
 - **Package**: `nette/schema` (dep: `nette/utils`); `master` = 2.0-dev,
   maintenance lives on `v1.x` branches
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		}
 	],
 	"require": {
-		"php": "8.1 - 8.5",
+		"php": "8.1 - 8.6",
 		"nette/utils": "^4.0"
 	},
 	"require-dev": {

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ Installation:
 composer require nette/schema
 ```
 
-It requires PHP version 8.1 and supports PHP up to 8.5.
+It requires PHP version 8.1 and supports PHP up to 8.6.
 
 
 [Support Me](https://github.com/sponsors/dg)


### PR DESCRIPTION
- new feature    <!-- #issue numbers, if any -->
- BC break? no
- doc PR: n/a

<!--
Please use the latest released version (ie. last tagged commit) as a base for PR.

Describe your changes here to communicate to the maintainers why we should accept this pull request.

Please add new tests to show the fix or feature works. And take a moment to read the contributing guide https://nette.org/en/contributing

Thanks for contributing to Nette!
-->
Add support for PHP 8.6, which has recently entered the beta phase (soft feature freeze) and will enter rc phase from September 22 onward. See also https://wiki.php.net/todo/php86.